### PR TITLE
Deprecate the frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,11 @@
 <head>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <meta charset=utf-8 />
-    <title>OSM Changesets and Notes | Mapbox</title>
+    <meta http-equiv="refresh" content="0; url=https://mapbox.com/" />
+    <title>Deprecated - OSM Changesets and Notes | Mapbox</title>
     <link rel='shortcut icon' href='path/to/favicon.ico' type='image/x-icon' />
-    <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-    <link href='assets/css/site.css' rel='stylesheet'>
 </head>
 <body>
-
-    <div class="app" id="application">
-
-    </div>
-    <script src="./dist/bundle.js" charset="UTF-8"></script>
+  <p><a href="https://mapbox.com/">Redirect</a></p>
 </body>
 </html>


### PR DESCRIPTION
Redirect to Mapbox.com as the osm-comments frontend is deprecated and no longer maintained.